### PR TITLE
Update to MadelineProto 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
         "madeline-proto"
     ],
     "require": {
-        "php": "^7.4|^8.0",
-        "danog/madelineproto": "^6",
+        "php": "^^8.0",
+        "danog/madelineproto": "^7",
         "illuminate/support": "^7.0|^8.0",
         "illuminate/console": "^7.0|^8.0",
         "illuminate/database": "^7.0|^8.0"


### PR DESCRIPTION
See the changelog at https://github.com/danog/MadelineProto/releases/tag/7.0.27
Make sure to run composer update and vendor/bin/phabel publish after tagging to bring back php7.1+ support.